### PR TITLE
added CONTRIBUTING.md and README contribution section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,44 @@
+# Contributing
+
+Thanks for considering a contribution! This project prefers small, focused pull requests that are easy to review.
+
+## Pick a task
+- Good first tasks: documentation clarifications, small UI tweaks, minor bug fixes, simple features (e.g., add a language option)
+- Not sure where to start? Open an issue titled like “Proposal: Add batch mode toggle” with a short outline
+
+## Workflow
+1) Fork the repository and create a feature branch from `main`  
+   Examples: `feat/batch-mode`, `fix/copy-toast`, `docs/contributing`
+
+2) Make your change and self‑test locally  
+   - Open `index.html` in a modern browser  
+   - Verify upload, crop, OCR, copy/download, and any UI you changed
+
+3) Write clear, present‑tense commits  
+   Examples: “Add batch mode toggle”, “Fix cropper modal close state”
+
+4) Open a Pull Request (PR)  
+   - Use the PR template  
+   - Include what/why, test steps, and screenshots/logs for UI/OCR output changes  
+   - Link related issues with “Fixes #123” when applicable
+
+5) Reviews  
+   - Keep scope small for faster reviews  
+   - Please respond to feedback promptly
+
+
+## Scope and quality
+- One focused change per PR; avoid unrelated edits
+- Prefer clarity over cleverness; keep diffs minimal and readable
+- For UI, ensure keyboard accessibility and sensible defaults
+
+## Sample names
+- Branches: `feat/language-selector`, `fix/clipboard-permission`, `docs/faq`
+- Commits: “Add language dropdown and persist selection”, “Handle clipboard write errors with toast”, “Document local testing tips”
+
+## Pull request checklist
+- Small, single‑purpose scope
+- Linked issue (if applicable)
+- Docs updated if behavior changes (README or this file)
+- Self‑tested locally; steps included in PR description
+- Screenshots for UI/visual changes

--- a/README.md
+++ b/README.md
@@ -8,3 +8,20 @@ A simple, client-side Image → Text converter using **Tesseract.js**.
 - 🖼️ Drag & Drop or 📂 File Picker for image input  
 - ⚙️ OCR powered by **Tesseract.js** (runs in-browser)  
 - 🌐 Language selection: **English**, **Hindi**, **Spanish**, **French** (add more via language codes)  
+
+
+## How to contribute  
+
+New to open source?
+ Welcome, focused improvements are perfect. 
+ See the full workflow in [CONTRIBUTING.md](./CONTRIBUTING.md).
+
+Quick start:
+- Fork this repo and create a branch from `main`  
+
+  Examples: `feat/batch-mode`, `fix/camera-permission`, `docs/readme-setup`
+
+- Pick a small task (or open an issue to propose one), make the change, and self‑test by opening `index.html` in a modern browser
+- Open a pull request using the template; describe what changed, why, test steps, and add screenshots for UI changes
+
+Thanks for helping make this tool better for everyone!


### PR DESCRIPTION
## Summary
Add a simple “How to contribute” section to README and introduce a full CONTRIBUTING.md to guide newcomers through fork-branch-PR workflow with sample branch and commit names
## What changed
- README: added a short, friendly contribution section linking to CONTRIBUTING.md.

## Why
Clear titles and structured PR descriptions help reviewers quickly understand scope, improving review speed and contributor experience, especially during Hacktoberfest

