### PR TITLE
Fix header text overlap by adding top padding

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -55,7 +55,12 @@ body.dark-mode .download-option {
 }
 
 /* --- Header & Main Layout --- */
-header { text-align: center; margin-bottom: 24px; position: relative; }
+header { 
+  text-align: center; 
+  margin-bottom: 24px; 
+  position: relative; 
+  padding-top: 30px;
+}
 /* Typing Header Effect Styles */
 header h1 {
   margin: 0;


### PR DESCRIPTION
### What
Adds 30px top padding to the header to prevent overlap between paragraph text and buttons.

### Why
On larger viewports, the paragraph and header buttons overlapped. This fixes the spacing.

### How to Test
1. Open index.html in a browser.
2. Confirm proper spacing between text and buttons.

### Screenshots
Before Fix
![Screenshot](https://drive.google.com/uc?export=view&id=1Vf-41MIZvl2eEiVunXIAmSYBQAboKe0F)

After fix
![Screenshot](https://drive.google.com/uc?export=view&id=1VPe6HwSGEKEqz4gHfKUC6mdYG1F808Ai)