### PR TITLE
Toggle Dark Mode button text between Dark and Light Mode

### DIFF
--- a/app.js
+++ b/app.js
@@ -78,9 +78,14 @@ document.addEventListener("DOMContentLoaded", () => {
   uploadBtn.addEventListener("click", () => fileInput.click());
   fileInput.addEventListener("change", (e) => handleFile(e.target.files[0]));
   cameraBtn.addEventListener("click", startCamera);
-  darkModeToggle.addEventListener("click", () =>
-    document.body.classList.toggle("dark-mode")
-  );
+  darkModeToggle.addEventListener("click", () => {
+    document.body.classList.toggle("dark-mode");
+    if (darkModeToggle.textContent === "Dark Mode") {
+      darkModeToggle.textContent = "Light Mode";
+    } else {
+      darkModeToggle.textContent = "Dark Mode";
+    }
+  });
 
   // Modal Controls
   cancelCropBtn.addEventListener("click", closeCropper);


### PR DESCRIPTION
### What
Update Dark Mode button text to switch between "Dark Mode" and "Light Mode" when toggled.

### Why
Previously, the Dark Mode button always displayed "Dark Mode" even after switching themes. This update improves UX clarity.

### How to Test
1. Open index.html in a browser.
2. Click the "Dark Mode" button.
3. Confirm the theme toggles and button text updates accordingly.

### Screenshots
**Before – Dark Mode active, text incorrect:**  
The page is in dark mode, but the button text still says “Dark Mode” instead of “Light Mode.”  
This could confuse users since the theme is already dark. 
![Screenshot](https://drive.google.com/uc?export=view&id=14eKUobRnU2vmMzgVxkKRtq3MFb_c0MnC)


**After – Dark Mode active, text correct:**  
Now, when dark mode is active, the button correctly shows “Light Mode.”  
This makes it clear to users that clicking the button will switch back to light mode.
![Screenshot](https://drive.google.com/uc?export=view&id=1aIBd0Ui3-W6Bxflv3iTrQ6-cVqFElo6S)
