### PR TITLE
Fix history panel to close when clicking outside

### DIFF
--- a/app.js
+++ b/app.js
@@ -124,6 +124,15 @@ document.addEventListener("DOMContentLoaded", () => {
   historyBtn.addEventListener("click", () =>
     historyPanel.classList.toggle("show")
   );
+  document.addEventListener("click", (e) => {
+    if (
+      historyPanel.classList.contains("show") &&
+      !historyPanel.contains(e.target) &&
+      e.target !== historyBtn
+    ) {
+      historyPanel.classList.remove("show");
+    }
+  });
   clearHistoryBtn.addEventListener("click", clearHistory);
 
   // --- Button Feedback Function (Unchanged) ---


### PR DESCRIPTION
### What
Fixed the History sidebar so it closes when clicking outside the panel.

### Why
Previously, the sidebar only closed when the History button was clicked again.
This improves UX consistency and usability.

### How to test
1. Click the "History" button → sidebar opens.
2. Click anywhere outside the sidebar → sidebar closes.
3. All other UI features still function correctly.

### Screenshots
Now, clicking anywhere will close the side panel
![Screenshot](https://drive.google.com/uc?export=view&id=1Q0XfY9CiXVzOBYUFpwFZfGS8MylYypwf)

Fixes #69 
